### PR TITLE
Add support for url-list (BEP19 / webseeding)

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,9 @@ var crypto = require('crypto')
 var FileReadStream = require('filestream/read')
 var flatten = require('lodash.flatten')
 var fs = require('fs')
-var inherits = require('inherits')
 var MultiStream = require('multistream')
 var once = require('once')
 var parallel = require('run-parallel')
-var stream = require('stream')
 
 var DEFAULT_ANNOUNCE_LIST = [
   ['udp://tracker.publicbt.com:80/announce'],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "bencode": "^0.6.0",
     "block-stream": "^0.0.7",
     "filestream": "1.0.1",
-    "inherits": "^2.0.1",
     "lodash.flatten": "^2.4.1",
     "minimist": "^0.2.0",
     "multistream": "^1.0.0",


### PR DESCRIPTION
This PR adds support for creating torrents with the optional 'url-list' field of BEP19 for webseeding.
