### PR TITLE
Feature/source string

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Or, an **array of `string`, `File`, `Buffer`, or `stream.Readable` objects**.
   private: Boolean,         // is this a private .torrent? (default = false)
   pieceLength: Number,      // force a custom piece length (number of bytes)
   announceList: [[String]], // custom trackers (array of arrays of strings) (see [bep12](http://www.bittorrent.org/beps/bep_0012.html))
-  urlList: [String]         // web seed urls (see [bep19](http://www.bittorrent.org/beps/bep_0019.html))
+  urlList: [String],        // web seed urls (see [bep19](http://www.bittorrent.org/beps/bep_0019.html))
+  info: Object              // add non-standard info dict entries, e.g. info.source, a convention for cross-seeding 
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ const announceList = [
  * @param  {number=} opts.pieceLength
  * @param  {Array.<Array.<string>>=} opts.announceList
  * @param  {Array.<string>=} opts.urlList
+ * @param  {Object} opts.info
  * @param  {function} cb
  * @return {Buffer} buffer of .torrent file data
  */
@@ -366,6 +367,8 @@ function onFiles (files, opts, cb) {
   if (opts.createdBy !== undefined) torrent['created by'] = opts.createdBy
 
   if (opts.private !== undefined) torrent.info.private = Number(opts.private)
+
+  if (opts.info !== undefined) Object.assign(torrent.info, opts.info)
 
   // "ssl-cert" key is for SSL torrents, see:
   //   - http://blog.libtorrent.org/2012/01/bittorrent-over-ssl/

--- a/test/source.js
+++ b/test/source.js
@@ -1,0 +1,76 @@
+const { join } = require('path')
+const folderPath = require('webtorrent-fixtures').folder.contentPath
+const parseTorrent = require('parse-torrent')
+const sha1 = require('simple-sha1')
+const test = require('tape')
+
+const createTorrent = require('../')
+
+test('verify info-hash without no source set (default)', t => {
+  t.plan(12)
+
+  createTorrent(folderPath, {
+    pieceLength: 262144, // matching mktorrent
+    announce: 'http://private.tracker.org/',
+    private: true
+  }, (err, torrent) => {
+    t.error(err)
+
+    const parsedTorrent = parseTorrent(torrent)
+
+    t.equals(parsedTorrent.name, 'folder')
+
+    t.equal(parsedTorrent.info.source, undefined, 'info.source not defined')
+
+    t.ok(parsedTorrent.private, 'private=true')
+
+    t.deepEqual(parsedTorrent.announce, ['http://private.tracker.org/'], 'single private announce url')
+
+    t.deepEquals(parsedTorrent.files[0].path, join('folder', 'file.txt'), 'check one and only file')
+    t.deepEquals(parsedTorrent.files[0].length, 15, 'file length')
+
+    t.equal(parsedTorrent.length, 15, 'total length = file length')
+    t.equal(parsedTorrent.info.pieces.length, 20)
+    t.equal(parsedTorrent.pieceLength, 262144)
+
+    t.deepEquals(parsedTorrent.pieces, ['799c11e348d39f1704022b8354502e2f81f3c037'])
+
+    t.equals(sha1.sync(parsedTorrent.infoBuffer), 'b4dfce1f956f720c928535ded617d07696a819ef', 'mktorrent hash with no source')
+  })
+})
+
+test('verify info-hash an additional source attribute set on the info dict (a way to allow private cross seeding of the same content)', t => {
+  t.plan(12)
+
+  createTorrent(folderPath, {
+    pieceLength: 262144, // matching mktorrent
+    announce: 'http://private.tracker.org/',
+    private: true,
+    info: { source: 'SOURCE' } // Set custom 'info source' attribute, this should result in a different info-hash
+  }, (err, torrent) => {
+    t.error(err)
+
+    const parsedTorrent = parseTorrent(torrent)
+
+    t.equals(parsedTorrent.name, 'folder')
+
+    t.ok(parsedTorrent.private, 'private=true')
+
+    // Source is now being read as a Buffer,
+    // if 'parse-torrent' is updated this test will still pass
+    t.equal(parsedTorrent.info.source.toString(), 'SOURCE', 'info.source=\'SOURCE\'')
+
+    t.deepEqual(parsedTorrent.announce, ['http://private.tracker.org/'], 'single private announce url')
+
+    t.deepEquals(parsedTorrent.files[0].path, join('folder', 'file.txt'), 'check one and only file')
+    t.deepEquals(parsedTorrent.files[0].length, 15, 'file length')
+
+    t.equal(parsedTorrent.length, 15, 'total length = file length')
+    t.equal(parsedTorrent.info.pieces.length, 20)
+    t.equal(parsedTorrent.pieceLength, 262144)
+
+    t.deepEquals(parsedTorrent.pieces, ['799c11e348d39f1704022b8354502e2f81f3c037'])
+
+    t.equals(sha1.sync(parsedTorrent.infoBuffer), 'a9499b56289356a3d5b8636387deb83709b8fa42', 'mktorrent run with -s SOURCE')
+  })
+})


### PR DESCRIPTION
Option for source string added to torrent info, included in infohash

Often used by private trackers to create a unique infohash to prevent peer-leak and the possibility to track the trackers that do use leaked torrents. 

The trick of this convention is that it will result a unique infohash which enforces a share scope limited to the assigned private tracker.

Reference: [mktorrent](https://github.com/Rudde/mktorrent/commit/905ccc2273a96ff0b6c774a67798a83af8cb334b)