### PR TITLE
Check for falsy input values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 'node'
+  - lts/*
 sudo: false
 env:
   global:

--- a/index.js
+++ b/index.js
@@ -64,10 +64,14 @@ function parseInput (input, opts, cb) {
  * Parse input file and return file information.
  */
 function _parseInput (input, opts, cb) {
-  if (Array.isArray(input) && input.length === 0) throw new Error('invalid input type')
-
   if (isFileList(input)) input = Array.prototype.slice.call(input)
   if (!Array.isArray(input)) input = [ input ]
+
+  if (input.length === 0) throw new Error('invalid input type')
+
+  input.forEach(function (item) {
+    if (item == null) throw new Error('invalid input type: ' + item)
+  })
 
   // In Electron, use the true file path
   input = input.map(function (item) {

--- a/test/error.js
+++ b/test/error.js
@@ -1,0 +1,26 @@
+var createTorrent = require('../')
+var test = require('tape')
+
+test('error handling', function (t) {
+  t.plan(5)
+
+  t.throws(function () {
+    createTorrent(null, function () {})
+  })
+
+  t.throws(function () {
+    createTorrent(undefined, function () {})
+  })
+
+  t.throws(function () {
+    createTorrent([null], function () {})
+  })
+
+  t.throws(function () {
+    createTorrent([undefined], function () {})
+  })
+
+  t.throws(function () {
+    createTorrent([null, undefined], function () {})
+  })
+})


### PR DESCRIPTION
Fixes #67. Prevent an uncaught exception by checking explicitly for falsy input values and throwing with a helpful error message.