### PR TITLE
Enhance the isBlob method

### DIFF
--- a/index.js
+++ b/index.js
@@ -403,7 +403,7 @@ function sumLength (sum, file) {
  * @return {boolean}
  */
 function isBlob (obj) {
-  return typeof Blob !== 'undefined' && obj instanceof Blob
+  return (typeof Blob !== 'undefined' && obj instanceof Blob) || (typeof File !== 'undefined' && obj instanceof File)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "standard": {
     "globals": [
       "Blob",
+      "File",
       "FileList"
     ]
   }


### PR DESCRIPTION
When using cordova-file-plugin, the File object it creates is not a instance of (does not inherit from) Blob , but the File object implements all methods of the Blob. Therefore, the isBlob method needs to judge this.