### PR TITLE
proper defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -324,7 +324,7 @@ function onFiles (files, opts, cb) {
 
   if (!announceList) announceList = []
 
-  if (global.WEBTORRENT_ANNOUNCE) {
+  if (global.WEBTORRENT_ANNOUNCE && announceList.length === 0) {
     if (typeof global.WEBTORRENT_ANNOUNCE === 'string') {
       announceList.push([ [ global.WEBTORRENT_ANNOUNCE ] ])
     } else if (Array.isArray(global.WEBTORRENT_ANNOUNCE)) {


### PR DESCRIPTION
Not sure how global works in Node 12+ but I can't seem to set global.WEBTORRENT_ANNOUNCE before create-torrent is imported. 

Seems saner to only add the global announce list if no announceList is provided.