### PR TITLE
fix: use for-await instead of the blockstream and multistream packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ async function getPieceList (files, pieceLength, estimatedTorrentLength, opts, c
 
   // promisify
   const sha1Hash = async (chunk) => {
-    return new Promise(resolve => sha1(chunk, hash => resolve(hash)))
+    return new Promise(resolve => sha1(chunk, resolve))
   }
 
   try {

--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ async function getPieceList (files, pieceLength, estimatedTorrentLength, opts, c
   // for storing data until there's a full chunk
   let bytesQueue = Buffer.alloc(0)
 
-  // promisify
+  // promisify sha1
   const sha1Hash = async (chunk) => {
     return new Promise(resolve => sha1(chunk, resolve))
   }

--- a/package.json
+++ b/package.json
@@ -19,13 +19,10 @@
   },
   "dependencies": {
     "bencode": "^2.0.1",
-    "block-stream2": "^2.1.0",
     "filestream": "^5.0.0",
     "is-file": "^1.0.0",
     "junk": "^3.1.0",
     "minimist": "^1.2.5",
-    "multistream": "^4.0.1",
-    "once": "^1.4.0",
     "piece-length": "^2.0.1",
     "queue-microtask": "^1.2.2",
     "readable-stream": "^3.6.0",


### PR DESCRIPTION
very similar to https://github.com/webtorrent/webtorrent/pull/1832

this allows the `multistream`, `blockstream2`, and `once` dependencies to be dropped

Compatibility shouldn't be an issue https://caniuse.com/#search=for%20await (and node >=10)