### PR TITLE
Fix: browser path handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,11 @@ function _parseInput (input, opts, cb) {
 
     item.path = path.split('/')
 
+    if (!Array.isArray(item.path)) {
+      commonPrefix = null
+      return
+    }
+
     // Remove initial slash
     if (!item.path[0]) {
       item.path.shift()


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
- Support browser file paths containing just the file name instad of a full path.

**Which issue (if any) does this pull request address?**
`Uncaught TypeError: item.path.shift is not a function at index.js:132`

**Is there anything you'd like reviewers to focus on?**
The issue happened when passing an array of File objects to WebTorrent's `seed` method.
Tested using `react-dropzone`.