### PR TITLE
refactor: change `announce` and `announceList`

### DIFF
--- a/test/announce.js
+++ b/test/announce.js
@@ -7,7 +7,7 @@ test('announce is added to torrent', t => {
   t.plan(4)
 
   createTorrent(fixtures.leaves.contentPath, {
-    announce: 'wss://example1.com',
+    announce: 'wss://example1.com'
   }, (err, torrent) => {
     t.error(err)
 

--- a/test/announce.js
+++ b/test/announce.js
@@ -1,0 +1,102 @@
+const fixtures = require('webtorrent-fixtures')
+const parseTorrent = require('parse-torrent')
+const test = require('tape')
+const createTorrent = require('../')
+
+test('announce is added to torrent', t => {
+  t.plan(4)
+
+  createTorrent(fixtures.leaves.contentPath, {
+    announce: 'wss://example1.com',
+  }, (err, torrent) => {
+    t.error(err)
+
+    const parsedTorrent = parseTorrent(torrent)
+
+    t.ok(Array.isArray(parsedTorrent.announce))
+
+    t.equals(parsedTorrent.announce.length, 1)
+
+    t.ok(parsedTorrent.announce.includes('wss://example1.com'))
+  })
+})
+
+test('invalid announceList as string', t => {
+  t.plan(3)
+
+  createTorrent(fixtures.leaves.contentPath, {
+    announceList: 'wss://example1.com'
+  }, (err, torrent) => {
+    t.error(err)
+
+    const parsedTorrent = parseTorrent(torrent)
+
+    t.ok(Array.isArray(parsedTorrent.announce))
+
+    t.equals(parsedTorrent.announce.length, 0)
+  })
+})
+
+test('announceList is a list of lists of strings', t => {
+  t.plan(6)
+
+  createTorrent(fixtures.leaves.contentPath, {
+    announceList: [['wss://example1.com', 'wss://example2.com'], ['wss://example3.com']]
+  }, (err, torrent) => {
+    t.error(err)
+
+    const parsedTorrent = parseTorrent(torrent)
+
+    t.ok(Array.isArray(parsedTorrent.announce))
+
+    t.equals(parsedTorrent.announce.length, 3)
+
+    t.ok(parsedTorrent.announce.includes('wss://example1.com'))
+
+    t.ok(parsedTorrent.announce.includes('wss://example2.com'))
+
+    t.ok(parsedTorrent.announce.includes('wss://example3.com'))
+  })
+})
+
+test('verify that announce and announceList can be used together', t => {
+  t.plan(5)
+
+  createTorrent(fixtures.leaves.contentPath, {
+    announce: 'wss://example1.com',
+    announceList: [['wss://example2.com']]
+  }, (err, torrent) => {
+    t.error(err)
+
+    const parsedTorrent = parseTorrent(torrent)
+
+    t.ok(Array.isArray(parsedTorrent.announce))
+
+    t.equals(parsedTorrent.announce.length, 2)
+
+    t.ok(parsedTorrent.announce.includes('wss://example1.com'))
+
+    t.ok(parsedTorrent.announce.includes('wss://example2.com'))
+  })
+})
+
+test('invalid trackers are discarded', t => {
+  t.plan(5)
+
+  createTorrent(fixtures.leaves.contentPath, {
+    announce: 'wss://example1.com',
+    announceList: [['wss://example2.com'], [1234, ['wss://thisisinsidealist.com']]]
+  }, (err, torrent) => {
+    t.error(err)
+
+    const parsedTorrent = parseTorrent(torrent)
+
+    t.ok(Array.isArray(parsedTorrent.announce))
+
+    t.equals(parsedTorrent.announce.length, 2)
+
+    t.ok(parsedTorrent.announce.includes('wss://example1.com'))
+
+    t.ok(parsedTorrent.announce.includes('wss://example2.com'))
+  })
+})


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[X] Other, please explain:
- Refactor of the `announce` and `announceList` parameters

**What changes did you make? (Give an overview)**
This PR:
- Allows to have different values in `announce` and `announceList`. The current code in master, depends on `announceList` being false to be able to use the `opts.announce`; which is good for parsing the torrent. But since we are creating it, I think we should allow to set both values (with no dependency on being false).

For example:

If we use `announce = "wss://example1.com"` and `announceList = [["wss://example2.com"]]`

The current code in master, would ignore the value in `announce`. This PR adds the `announce` value to `announceList`.

- Adds more validations to the tracker lists

**Which issue (if any) does this pull request address?**
Not directly, but the issue seen in #118 would have had a better output. In that particular case (with the new changes), an invalid `announceList` will not throw an error and just discard the invalid trackers.

**Is there anything you'd like reviewers to focus on?**
