### PR TITLE
fix: hange default flat() to 64 from 1 to catch nested folders

### DIFF
--- a/get-files.js
+++ b/get-files.js
@@ -38,7 +38,7 @@ function getFiles (path, keepRoot, cb) {
   traversePath(path, getFileInfo, (err, files) => {
     if (err) return cb(err)
 
-    if (Array.isArray(files)) files = files.flat()
+    if (Array.isArray(files)) files = files.flat(64)
     else files = [files]
 
     path = corePath.normalize(path)


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Passed a parameter to the Array.flat() call to change from the default 1 level.

**Which issue (if any) does this pull request address?**
create-torrent will crash if the folder is deeply nested beyond 1 level since the forEach expects a specific object and not an array of objects.

**Is there anything you'd like reviewers to focus on?**
This is a crutch and likely not the best fix, but absolutely seems to work.
