### PR TITLE
fix: exception on folder depth > 1

### DIFF
--- a/get-files.js
+++ b/get-files.js
@@ -38,7 +38,7 @@ function getFiles (path, keepRoot, cb) {
   traversePath(path, getFileInfo, (err, files) => {
     if (err) return cb(err)
 
-    if (Array.isArray(files)) files = files.flat()
+    if (Array.isArray(files)) files = files.flat(Infinity)
     else files = [files]
 
     path = corePath.normalize(path)


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Fixes an undefined access exception when creating torrents from folder where depth is greater than 1 level deep

**Which issue (if any) does this pull request address?**

Related: #153

**Is there anything you'd like reviewers to focus on?**

N/A
