### PR TITLE
fix: replace filestream with fast-blob-stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const bencode = require('bencode')
 const BlockStream = require('block-stream2')
 const calcPieceLength = require('piece-length')
 const corePath = require('path')
-const FileReadStream = require('filestream/read')
+const { BlobReadStream } = require('fast-blob-stream')
 const isFile = require('is-file')
 const junk = require('junk')
 const MultiStream = require('multistream')
@@ -412,7 +412,7 @@ function isReadable (obj) {
  * @return {function}
  */
 function getBlobStream (file) {
-  return () => new FileReadStream(file)
+  return () => new BlobReadStream(file)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "bencode": "^2.0.2",
     "block-stream2": "^2.1.0",
-    "filestream": "^5.0.0",
+    "fast-blob-stream": "^1.0.2",
     "is-file": "^1.0.0",
     "junk": "^3.1.0",
     "minimist": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "bencode": "^2.0.2",
     "block-stream2": "^2.1.0",
-    "fast-blob-stream": "^1.0.2",
+    "fast-blob-stream": "^1.0.3",
     "is-file": "^1.0.0",
     "junk": "^3.1.0",
     "minimist": "^1.2.5",


### PR DESCRIPTION
drops filereader dep and readable-stream dep

<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[X] Other, please explain:

**What changes did you make? (Give an overview)**
Replaced `filestream` with `fast-blob-stream` which is not only MILES faster, doesn't rely on buffer or readable-stream. It does however use marginally more RAM as it caches 1 piece ahead [if possible]. They are functionally the same.
**Which issue (if any) does this pull request address?**
https://github.com/webtorrent/webtorrent/issues/1971

**Is there anything you'd like reviewers to focus on?**
Does this cause any issues on node? I don't think node has `file`, however it's reliance on `blob` which later versions of node have might be an issue as it uses w3c `ReadableStream` to create a node-like `Readable` which is implemented poorly in later node versions, so it might be misused, is this a potential issue?