### PR TITLE
fix: drop block-stream, drop streamx

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,18 +19,16 @@
   },
   "dependencies": {
     "bencode": "^2.0.3",
-    "block-stream2": "^2.1.0",
-    "fast-blob-stream": "^1.1.1",
+    "block-iterator": "^1.0.1",
+    "fast-readable-async-iterator": "^1.1.1",
     "is-file": "^1.0.0",
     "join-async-iterator": "^1.1.1",
     "junk": "^3.1.0",
     "minimist": "^1.2.5",
-    "once": "^1.4.0",
     "piece-length": "^2.0.1",
     "queue-microtask": "^1.2.3",
     "run-parallel": "^1.2.0",
-    "simple-sha1": "^3.1.0",
-    "streamx": "^2.12.4"
+    "simple-sha1": "^3.1.0"
   },
   "devDependencies": {
     "@webtorrent/semantic-release-config": "1.0.8",


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Replaced `block-stream` with `block-iterator` it's ~~ 20% faster when using forawait. Full replace because the original repo no longer exists. Replaced all streams with iterators removing all stream dependecies, feels kind of dumb as we just migrated from `readable-stream` to `streamx` lol. `once` is also dropped as it's no longer needed.
**Which issue (if any) does this pull request address?**
https://github.com/webtorrent/webtorrent/issues/1971
https://github.com/webtorrent/create-torrent/pull/115/files [closes]
