### PR TITLE
Update docs and add tracker.webtorrent.dev to the default announceList

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If `announceList` is omitted, the following trackers will be included automatica
 - udp://exodus.desync.com:6969
 - wss://tracker.btorrent.xyz
 - wss://tracker.openwebtorrent.com
-- wss://tracker.fastcast.nz
+- wss://tracker.webtorrent.dev
 
 Trackers that start with `wss://` are for WebRTC peers. See
 [WebTorrent](https://webtorrent.io) to learn more.

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ Or, an **array of `string`, `File`, `Buffer`, or `stream.Readable` objects**.
 
 If `announceList` is omitted, the following trackers will be included automatically:
 
-- udp://tracker.openbittorrent.com:80
-- udp://tracker.internetwarriors.net:1337
 - udp://tracker.leechers-paradise.org:6969
 - udp://tracker.coppersurfer.tk:6969
-- udp://exodus.desync.com:6969
+- udp://tracker.opentrackr.org:1337
+- udp://explodie.org:6969
+- udp://tracker.empire-js.us:1337
 - wss://tracker.btorrent.xyz
 - wss://tracker.openwebtorrent.com
 - wss://tracker.webtorrent.dev

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ const announceList = [
   ['udp://explodie.org:6969'],
   ['udp://tracker.empire-js.us:1337'],
   ['wss://tracker.btorrent.xyz'],
-  ['wss://tracker.openwebtorrent.com']
+  ['wss://tracker.openwebtorrent.com'],
+  ['wss://tracker.webtorrent.dev']
 ]
 
 /**


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain:

**What changes did you make? (Give an overview)**

This PR updates documentation to remove `tracker.fastcast.nz` which was removed in commit b0fcef428c5a89c88d0b3ead570566568c16288d and proposed to add `wss://tracker.webtorrent.dev`, which is a public WebTorrent tracker I run, which uses [Aqiatic](https://github.com/greatest-ape/aquatic)'s WebSocket implementation. 

Aquatic is a high performance BitTorrent tracker, which public trackers such as explodie.org use to handle 80,000 requests a second.

**Which issue (if any) does this pull request address?**

N/A

**Is there anything you'd like reviewers to focus on?**

N/A