### PR TITLE
feat: add maxPieceLength option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Or, an **array of `string`, `File`, `Buffer`, or `stream.Readable` objects**.
   filterJunkFiles: Boolean, // remove hidden and other junk files? (default = true)
   private: Boolean,         // is this a private .torrent? (default = false)
   pieceLength: Number,      // force a custom piece length (number of bytes)
-  maxPieceLength: Number,   // force a maximum piece length for auto piece length selection, does not affect pieceLength option (default = Infinity)
+  maxPieceLength: Number,   // force a maximum piece length for auto piece length selection, does not affect pieceLength option (default = 4 MiB)
   announceList: [[String]], // custom trackers (array of arrays of strings) (see [bep12](http://www.bittorrent.org/beps/bep_0012.html))
   urlList: [String],        // web seed urls (see [bep19](http://www.bittorrent.org/beps/bep_0019.html))
   info: Object,             // add non-standard info dict entries, e.g. info.source, a convention for cross-seeding

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Or, an **array of `string`, `File`, `Buffer`, or `stream.Readable` objects**.
   filterJunkFiles: Boolean, // remove hidden and other junk files? (default = true)
   private: Boolean,         // is this a private .torrent? (default = false)
   pieceLength: Number,      // force a custom piece length (number of bytes)
+  maxPieceLength: Number,   // force a maximum piece length for auto piece length selection, does not affect pieceLength option (default = Infinity)
   announceList: [[String]], // custom trackers (array of arrays of strings) (see [bep12](http://www.bittorrent.org/beps/bep_0012.html))
   urlList: [String],        // web seed urls (see [bep19](http://www.bittorrent.org/beps/bep_0019.html))
   info: Object,             // add non-standard info dict entries, e.g. info.source, a convention for cross-seeding

--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ function _parseInput (input, opts, cb) {
   }
 
   if (!opts.maxPieceLength) {
-    opts.maxPieceLength = Infinity
+    opts.maxPieceLength = 4 * 1024 * 1024
   }
 
   const numPaths = input.reduce((sum, item) => sum + Number(typeof item === 'string'), 0)

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ const announceList = [
  * @param  {string=} opts.createdBy
  * @param  {boolean|number=} opts.private
  * @param  {number=} opts.pieceLength
+ * @param  {number=} opts.maxPieceLength
  * @param  {Array.<Array.<string>>=} opts.announceList
  * @param  {Array.<string>=} opts.urlList
  * @param  {Object=} opts.info
@@ -149,6 +150,10 @@ function _parseInput (input, opts, cb) {
 
   if (!opts.name) {
     opts.name = `Unnamed Torrent ${Date.now()}`
+  }
+
+  if (!opts.maxPieceLength) {
+    opts.maxPieceLength = Infinity
   }
 
   const numPaths = input.reduce((sum, item) => sum + Number(typeof item === 'string'), 0)
@@ -300,7 +305,7 @@ function onFiles (files, opts, cb) {
   if (opts.urlList !== undefined) torrent['url-list'] = opts.urlList
 
   const estimatedTorrentLength = files.reduce(sumLength, 0)
-  const pieceLength = opts.pieceLength || calcPieceLength(estimatedTorrentLength)
+  const pieceLength = opts.pieceLength || Math.min(calcPieceLength(estimatedTorrentLength), opts.maxPieceLength)
   torrent.info['piece length'] = pieceLength
 
   getPieceList(

--- a/test/basic.js
+++ b/test/basic.js
@@ -205,3 +205,57 @@ test('implicit torrent name from file names with slashes in them', t => {
     t.equal(parsedTorrent.files[1].path, path.join('My Cool Folder', 'My Cool File 2'))
   })
 })
+
+test('verify torrent length with maxPieceLength set', t => {
+  t.plan(8)
+
+  const buf1 = Buffer.from('buf1')
+  buf1.name = 'My Cool Folder/My Cool File 1'
+
+  const buf2 = Buffer.from('buf2')
+  buf2.name = 'My Cool Folder/My Cool File 2'
+
+  createTorrent([buf1, buf2], { maxPieceLength: 10 }, async (err, torrent) => {
+    t.error(err)
+    const parsedTorrent = await parseTorrent(torrent)
+
+    t.equal(parsedTorrent.name, 'My Cool Folder')
+
+    t.equal(parsedTorrent.files.length, 2)
+
+    t.equal(parsedTorrent.files[0].name, 'My Cool File 1')
+    t.equal(parsedTorrent.files[0].path, path.join('My Cool Folder', 'My Cool File 1'))
+
+    t.equal(parsedTorrent.files[1].name, 'My Cool File 2')
+    t.equal(parsedTorrent.files[1].path, path.join('My Cool Folder', 'My Cool File 2'))
+
+    t.equal(parsedTorrent.pieceLength, 10)
+  })
+})
+
+test('verify maxPieceLength is ignored when pieceLength is manually set', t => {
+  t.plan(8)
+
+  const buf1 = Buffer.from('buf1')
+  buf1.name = 'My Cool Folder/My Cool File 1'
+
+  const buf2 = Buffer.from('buf2')
+  buf2.name = 'My Cool Folder/My Cool File 2'
+
+  createTorrent([buf1, buf2], { pieceLength: 1024, maxPieceLength: 10 }, async (err, torrent) => {
+    t.error(err)
+    const parsedTorrent = await parseTorrent(torrent)
+
+    t.equal(parsedTorrent.name, 'My Cool Folder')
+
+    t.equal(parsedTorrent.files.length, 2)
+
+    t.equal(parsedTorrent.files[0].name, 'My Cool File 1')
+    t.equal(parsedTorrent.files[0].path, path.join('My Cool Folder', 'My Cool File 1'))
+
+    t.equal(parsedTorrent.files[1].name, 'My Cool File 2')
+    t.equal(parsedTorrent.files[1].path, path.join('My Cool Folder', 'My Cool File 2'))
+
+    t.equal(parsedTorrent.pieceLength, 1024)
+  })
+})


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

This PR adds the new option `maxPieceLength` to provide an upper limit of what the automatic piece length calculation will be set to. This was requested in #266, as some clients run into issues with a `pieceLength` > 16M).

**Which issue (if any) does this pull request address?**
- fixes #266 

**Is there anything you'd like reviewers to focus on?**
- Should this also affect the `pieceLength` argument, or throw an error when both are used and `pieceLength` > `maxPieceLength`?
