### PR TITLE
feat: add wss://open.ftorrent.com to default announceList

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ If `announceList` is omitted, the following trackers will be included automatica
 - wss://tracker.btorrent.xyz
 - wss://tracker.openwebtorrent.com
 - wss://tracker.webtorrent.dev
+- wss://open.ftorrent.com
 
 Trackers that start with `wss://` are for WebRTC peers. See
 [WebTorrent](https://webtorrent.io) to learn more.

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ const announceList = [
   ['udp://tracker.empire-js.us:1337'],
   ['wss://tracker.btorrent.xyz'],
   ['wss://tracker.openwebtorrent.com'],
-  ['wss://tracker.webtorrent.dev']
+  ['wss://tracker.webtorrent.dev'],
+  ['wss://open.ftorrent.com']
 ]
 
 /**


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Hello! First PR here, so: WebTorrent is the reason my tracker serves browser peers at all — thank you for building it and keeping it alive. It's been a genuine pleasure running infrastructure for this ecosystem.

This adds `wss://open.ftorrent.com` to the default `announceList` (index.js and README).

- **Implementation:** [Aquatic](https://github.com/greatest-ape/aquatic) — the same tracker software as `tracker.webtorrent.dev`
- **Operator:** me (zootella); the deployment is public and documented at [zootella/ftorrent](https://github.com/zootella/ftorrent/tree/master/open), with live stats at [open.ftorrent.com](https://open.ftorrent.com/)
- **Operational history:** the same host serves `udp://open.ftorrent.com:443/announce` and `https://open.ftorrent.com/announce` for the broader BitTorrent ecosystem — roughly 100M announces a day at 98%+ uptime since launching 2026-04-08
- **Validation:** tested with the webtorrent community on Discord

**Which issue (if any) does this pull request address?**

None.

**Is there anything you'd like reviewers to focus on?**

Opening as a draft: I recognize defaults are a long-term commitment and this tracker's history is short next to the others in the list. Happy to wait as long as makes sense, and happy to be removed unilaterally if issues ever surface.

What would you want to see — uptime duration, traffic, anything else — before this would be ready to merge?
