### PR TITLE
fix: derive torrent name from common parent directory for array of file paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,6 +134,29 @@ function _parseInput (input, opts, cb) {
     opts.name = commonPrefix
   }
 
+  // When seeding an array of multiple file-path strings with no explicit name,
+  // derive the torrent name from the common parent directory of the paths. The
+  // `commonPrefix` logic above only applies to File/Blob objects, so an array
+  // of path strings would otherwise fall through to the first file's basename
+  // below, nesting every file under it (e.g. `index.html/index.html`).
+  // See webtorrent/webtorrent#983.
+  if (!opts.name) {
+    const stringPaths = input.filter(item => typeof item === 'string')
+    if (stringPaths.length > 1 && stringPaths.length === input.length) {
+      let commonDir = corePath.dirname(corePath.resolve(stringPaths[0]))
+      for (const filePath of stringPaths.slice(1)) {
+        const fileDir = corePath.dirname(corePath.resolve(filePath))
+        while (commonDir !== corePath.dirname(commonDir)) {
+          const relativePath = corePath.relative(commonDir, fileDir)
+          if (relativePath !== '..' && !relativePath.startsWith(`..${corePath.sep}`) && !corePath.isAbsolute(relativePath)) break
+          commonDir = corePath.dirname(commonDir)
+        }
+      }
+      const name = corePath.basename(commonDir)
+      if (name) opts.name = name
+    }
+  }
+
   if (!opts.name) {
     // use first user-set file name
     input.some(item => {

--- a/test/fs.js
+++ b/test/fs.js
@@ -235,3 +235,25 @@ test('create multi file torrent with array of paths', t => {
     })
   })
 })
+
+test('create multi file torrent from array of paths without a name uses the common parent directory', t => {
+  t.plan(5)
+
+  const oneTxt = path.join(fixtures.numbers.contentPath, '1.txt')
+  const twoTxt = path.join(fixtures.numbers.contentPath, '2.txt')
+
+  createTorrent([oneTxt, twoTxt], async (err, torrent) => {
+    t.error(err)
+
+    const parsedTorrent = await parseTorrent(torrent)
+
+    // The name is derived from the files' common parent directory ("numbers"),
+    // not the first file's basename ("1.txt"), which would otherwise nest every
+    // file under it (e.g. `1.txt/1.txt`). See webtorrent/webtorrent#983.
+    t.equals(parsedTorrent.name, 'numbers')
+
+    t.equals(parsedTorrent.files.length, 2)
+    t.deepEquals(path.normalize(parsedTorrent.files[0].path), path.normalize('numbers/1.txt'))
+    t.deepEquals(path.normalize(parsedTorrent.files[1].path), path.normalize('numbers/2.txt'))
+  })
+})


### PR DESCRIPTION
## What
When seeding an array of multiple file-path strings without an explicit `name`, create-torrent names the torrent after the first file's basename, which nests every file under it (e.g. `index.html/index.html`). The `commonPrefix` logic only applies to `File`/`Blob` objects with paths, so an array of path strings falls through to the first-file-basename fallback.

## Fix
Before that fallback, when the input is an array of 2+ path strings and no `name` was given, derive the name from the common parent directory of the paths (via `corePath`). Single files, `File`/`Blob` objects, and mixed inputs are unaffected (the branch is guarded to all-string arrays of length > 1).

## Tests
Added a regression test in `test/fs.js`: seeding `[numbers/1.txt, numbers/2.txt]` with no name now produces name `numbers` and files `numbers/1.txt`, `numbers/2.txt`. Full suite passes (`standard` + `tape`).

Fixes webtorrent/webtorrent#983. This is the create-torrent-side fix; @ThaUnknown noted on webtorrent/webtorrent#3084 that the name derivation belongs here rather than in webtorrent's index.js.